### PR TITLE
perf: Vec::resize instead of iter::repeat_n (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pad and format directly into preallocated buffers.
 
 ## Installation
 
-Add to you project with Cargo:
+Add to your project with Cargo:
 
 ```
 cargo add padder
@@ -40,6 +40,9 @@ cargo add padder
 
 
 ## Usage
+
+Simply bring the desired trait into scope in your project.
+
 
 ### Immutable padding
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,6 @@ mod tests_wrappers {
     fn str_pad() {
         let output = pad("little big planet", 20, Alignment::Center, '!');
         assert_eq!("!little big planet!!", output);
-        assert_eq!(20, output.capacity());
         assert_eq!(20, output.len());
     }
 
@@ -145,7 +144,6 @@ mod tests_wrappers {
     fn string_pad() {
         let output = pad("uh oh", 8, Alignment::Right, '💣');
         assert_eq!("💣💣💣uh oh", output);
-        assert_eq!(17, output.capacity());
         assert_eq!(17, output.len());
     }
 
@@ -154,7 +152,6 @@ mod tests_wrappers {
         let mut s = String::from("def fn(xd: str) -> None: ...");
         pad_mut(&mut s, 30, Alignment::Left, 'æ');
         assert_eq!("def fn(xd: str) -> None: ...ææ", s);
-        assert_eq!(32, s.capacity());
         assert_eq!(32, s.len());
         assert_eq!(30, s.chars().count());
     }
@@ -163,11 +160,9 @@ mod tests_wrappers {
     fn vec_pad_to_buffer() {
         let mut buffer: Vec<u8> = Vec::new();
         let v: Vec<u8> = Vec::from(&[1u8, 2]);
-        assert_eq!(2, v.capacity());
         assert_eq!(2, v.len());
         pad_to_buffer(v, 4, Alignment::Right, 89u8, &mut buffer);
         assert_eq!(Vec::from(&[89u8, 89, 1, 2]), buffer);
-        assert_eq!(4, buffer.capacity());
         assert_eq!(4, buffer.len());
     }
 
@@ -176,7 +171,6 @@ mod tests_wrappers {
         let source: &[bool] = &[true, false, true, true];
         let s = source.pad(6, Alignment::Center, false);
         assert_eq!(Vec::from(&[false, true, false, true, true, false]), s);
-        assert_eq!(6, s.capacity());
         assert_eq!(6, s.len());
     }
 }

--- a/src/mutable_source.rs
+++ b/src/mutable_source.rs
@@ -48,7 +48,6 @@ impl MutableSource for &mut String {
     /// (&mut s).pad(width, Alignment::Center, '¡');  // "¡Visa Vid Vindens Ängar¡¡"
     ///
     /// assert_eq!(25, s.chars().count());
-    /// assert_eq!(23 + 2 * 3, s.capacity());  // '¡' = 2 bytes & 'Ä' = 2 bytes
     /// ```
     /// [`insert()`]: String::insert()
     #[cfg(not(feature = "enable_unsafe"))]
@@ -94,7 +93,6 @@ impl MutableSource for &mut String {
                     self.truncate(ed_byte - st_byte);
                 }
             };
-            self.shrink_to_fit();
             return;
         }
 
@@ -108,8 +106,6 @@ impl MutableSource for &mut String {
 
         new_s.push_str(self);
         new_s.push_str(&std::iter::repeat_n(symbol, pads.right()).collect::<String>());
-
-        new_s.shrink_to_fit();
         **self = new_s;
     }
 
@@ -141,10 +137,8 @@ impl MutableSource for &mut String {
     /// (&mut s).pad(width, Alignment::Right, '-');  // "----sackboy
     ///
     /// let mut expected = String::from("----sackboy");
-    /// expected.shrink_to_fit();
     ///
     /// assert_eq!(11, s.chars().count());
-    /// assert_eq!(11, s.capacity());
     /// assert_eq!(expected.len(), s.len());
     /// assert_eq!(expected, s);
     /// ```
@@ -196,7 +190,6 @@ impl MutableSource for &mut String {
                     self.truncate(ed_byte - st_byte);
                 }
             }
-            self.shrink_to_fit();
             return;
         }
 
@@ -273,7 +266,6 @@ where
     ///     DummyStruct { a: 1, b: false },
     ///     DummyStruct { a: 15, b: false },
     /// ]);
-    /// v.shrink_to_fit();
     ///
     /// let width: usize = 7;
     /// (&mut v).pad(width, Alignment::Right, DummyStruct { a: 1337, b: true });
@@ -287,10 +279,8 @@ where
     ///     DummyStruct { a: 1, b: false },
     ///     DummyStruct { a: 15, b: false },
     /// ]);
-    /// expected.shrink_to_fit();
     ///
     /// assert_eq!(expected.len(), v.len());
-    /// assert_eq!(expected.capacity(), v.capacity());
     /// assert_eq!(expected, v);
     ///
     /// // we can modify the original vec again!
@@ -318,7 +308,6 @@ where
                     self.truncate(width);
                 }
             }
-            self.shrink_to_fit();
             return;
         }
 
@@ -331,9 +320,7 @@ where
         let mut new_v: Vec<T> = std::iter::repeat_n(symbol, pads.left()).collect();
 
         new_v.extend_from_slice(self);
-        new_v.extend_from_slice(&std::iter::repeat_n(symbol, pads.right()).collect::<Vec<T>>());
-
-        new_v.shrink_to_fit();
+        new_v.resize(width, symbol);
         **self = new_v;
     }
 }
@@ -348,7 +335,6 @@ mod tests_string {
         let mut source = String::from("Vilhelm Moberg");
         (&mut source).pad(width, Alignment::Left, '@');
         let expected = String::from("Vilhelm Moberg@@@");
-        assert_eq!(expected.capacity(), source.capacity());
         assert_eq!(expected.len(), source.len());
         assert_eq!(expected, source);
     }
@@ -359,7 +345,6 @@ mod tests_string {
         let mut source = String::from("rocketTT");
         (&mut source).pad(width, Alignment::Right, '🚀');
         let expected = String::from("🚀🚀🚀🚀rocketTT");
-        assert_eq!(expected.capacity(), source.capacity());
         assert_eq!(expected.len(), source.len());
         assert_eq!(expected, source);
     }
@@ -370,7 +355,6 @@ mod tests_string {
         let mut source = String::from("plant");
         (&mut source).pad(width, Alignment::Center, 'き');
         let expected = String::from("きplantきき");
-        assert_eq!(expected.capacity(), source.capacity());
         assert_eq!(expected.len(), source.len());
         assert_eq!(expected, source);
     }
@@ -381,7 +365,6 @@ mod tests_string {
         let mut source = String::from("實real實");
         (&mut source).pad(width, Alignment::Center, '實');
         let expected = String::from("實實實實實實real實實實實實實");
-        assert_eq!(expected.capacity(), source.capacity());
         assert_eq!(expected.len(), source.len());
         assert_eq!(expected, source);
     }
@@ -392,7 +375,6 @@ mod tests_string {
         let mut source = String::from("實real實");
         (&mut source).pad(width, Alignment::Left, '實');
         let expected = String::from("實re");
-        assert_eq!(expected.capacity(), source.capacity());
         assert_eq!(expected.len(), source.len());
         assert_eq!(expected, source);
     }
@@ -403,7 +385,6 @@ mod tests_string {
         let mut source = String::from("實real實");
         (&mut source).pad(width, Alignment::Right, '實');
         let expected = String::from("real實");
-        assert_eq!(expected.capacity(), source.capacity());
         assert_eq!(expected.len(), source.len());
         assert_eq!(expected, source);
     }
@@ -414,7 +395,6 @@ mod tests_string {
         let mut source = String::from("實vamos實carlito實");
         (&mut source).pad(width, Alignment::Center, '實');
         let expected = String::from("os實car");
-        assert_eq!(expected.capacity(), source.capacity());
         assert_eq!(expected.len(), source.len());
         assert_eq!(expected, source);
     }
@@ -425,7 +405,6 @@ mod tests_string {
         let mut source = String::from("實vamos實carlito實");
         (&mut source).pad(width, Alignment::Center, '實');
         let expected = String::from("os實carl");
-        assert_eq!(expected.capacity(), source.capacity());
         assert_eq!(expected.len(), source.len());
         assert_eq!(expected, source);
     }
@@ -441,7 +420,6 @@ mod tests_vec {
         let mut source: Vec<u32> = Vec::from(&[1u32, 2, 3]);
         (&mut source).pad(width, Alignment::Left, 1337);
         let expected: Vec<u32> = Vec::from(&[1u32, 2, 3, 1337]);
-        assert_eq!(expected.capacity(), source.capacity());
         assert_eq!(expected.len(), source.len());
         assert_eq!(expected, source);
     }
@@ -452,7 +430,6 @@ mod tests_vec {
         let mut source: Vec<i32> = Vec::from(&[1i32, 2, 3]);
         (&mut source).pad(width, Alignment::Right, -1998);
         let expected: Vec<i32> = Vec::from(&[-1998i32, -1998, -1998, 1, 2, 3]);
-        assert_eq!(expected.capacity(), source.capacity());
         assert_eq!(expected.len(), source.len());
         assert_eq!(expected, source);
     }
@@ -463,7 +440,6 @@ mod tests_vec {
         let mut source: Vec<char> = Vec::from(&['😺', '2', '¡']);
         (&mut source).pad(width, Alignment::Center, '🐛');
         let expected: Vec<char> = Vec::from(&['🐛', '😺', '2', '¡', '🐛', '🐛']);
-        assert_eq!(expected.capacity(), source.capacity());
         assert_eq!(expected.len(), source.len());
         assert_eq!(expected, source);
     }
@@ -474,7 +450,6 @@ mod tests_vec {
         let mut source: Vec<char> = Vec::from(&['😺', '2', '¡']);
         (&mut source).pad(width, Alignment::Center, '🐛');
         let expected: Vec<char> = Vec::from(&['🐛', '🐛', '😺', '2', '¡', '🐛', '🐛']);
-        assert_eq!(expected.capacity(), source.capacity());
         assert_eq!(expected.len(), source.len());
         assert_eq!(expected, source);
     }
@@ -485,7 +460,6 @@ mod tests_vec {
         let mut source: Vec<char> = Vec::from(&['😺', '2', '¡']);
         (&mut source).pad(width, Alignment::Left, ' ');
         let expected: Vec<char> = Vec::from(&['😺', '2']);
-        assert_eq!(expected.capacity(), source.capacity());
         assert_eq!(expected.len(), source.len());
         assert_eq!(expected, source);
     }
@@ -512,7 +486,6 @@ mod tests_vec {
             DummyStruct { a: true },
         ]);
 
-        assert_eq!(expected.capacity(), source.capacity());
         assert_eq!(expected.len(), source.len());
         assert_eq!(expected, source);
     }
@@ -536,7 +509,6 @@ mod tests_vec {
             "beethoven",
             "mozart",
         ]);
-        assert_eq!(expected.capacity(), source.capacity());
         assert_eq!(expected.len(), source.len());
         assert_eq!(expected, source);
     }
@@ -561,7 +533,6 @@ mod tests_vec {
             "mozart",
             "chopin",
         ]);
-        assert_eq!(expected.capacity(), source.capacity());
         assert_eq!(expected.len(), source.len());
         assert_eq!(expected, source);
     }

--- a/src/source.rs
+++ b/src/source.rs
@@ -113,13 +113,11 @@ impl Source for &str {
     /// let s1 = "yabadoo";
     /// let o1 = s1.pad(10, Alignment::Right, '9');
     /// assert_eq!("999yabadoo", o1);
-    /// assert_eq!(10, o1.capacity());  // all of these chars are just 1 byte
     /// assert_eq!(10, o1.len());
     ///
     /// let s2 = "øĸœ";
     /// let o2 = s2.pad(6, Alignment::Center, '🦔');
     /// assert_eq!("🦔øĸœ🦔🦔", o2);
-    /// assert_eq!(18, o2.capacity());  // these utf8 chars use more bytes :)
     /// assert_eq!(18, o2.len());
     /// ```
     fn pad(&self, width: usize, mode: Alignment, symbol: Self::Symbol) -> Self::Output {
@@ -170,7 +168,6 @@ impl Source for &str {
     /// s.pad_to_buffer(width, Alignment::Left, symbol, &mut buf);
     ///
     /// assert_eq!("caribbean🌊🌊🌊", buf);
-    /// assert_eq!(21, buf.capacity());
     /// assert_eq!(21, buf.len());
     /// ```
     fn pad_to_buffer(
@@ -267,7 +264,6 @@ impl Source for String {
     /// let s = String::from("hobbit");
     /// let o = s.pad(10, Alignment::Right, '風');
     /// assert_eq!("風風風風hobbit", o);
-    /// assert_eq!(18, o.capacity());  // '風' is 3 bytes
     /// assert_eq!(18, o.len());
     /// ```
     fn pad(&self, width: usize, mode: Alignment, symbol: Self::Symbol) -> Self::Output {
@@ -320,7 +316,6 @@ impl Source for String {
     /// s.pad_to_buffer(width, Alignment::Center, symbol, &mut buf);
     ///
     /// assert_eq!("🚗f1🚗", buf);
-    /// assert_eq!(10, buf.capacity());
     /// assert_eq!(10, buf.len());
     /// ```
     fn pad_to_buffer(
@@ -391,7 +386,6 @@ where
     /// let v: Vec<&str> = Vec::from(&["scooby", "doo"]);
     /// let o = v.pad(5, Alignment::Left, "!!");
     /// assert_eq!(Vec::from(&["scooby", "doo", "!!", "!!", "!!"]), o);
-    /// assert_eq!(5, o.capacity());
     /// assert_eq!(5, o.len());
     /// ```
     fn pad(&self, width: usize, mode: Alignment, symbol: Self::Symbol) -> Self::Output {
@@ -409,8 +403,7 @@ where
         let pads = mode.pads(n_items_diff);
         let mut output: Vec<T> = std::iter::repeat_n(symbol, pads.left()).collect::<Vec<T>>();
         output.extend_from_slice(self);
-        output.extend_from_slice(&std::iter::repeat_n(symbol, pads.right()).collect::<Vec<T>>());
-        output.shrink_to_fit();
+        output.resize(width, symbol);
         output
     }
 
@@ -458,7 +451,6 @@ where
     ///     ]);
     ///
     ///     assert_eq!(expected, buf);
-    ///     assert_eq!(expected.capacity(), buf.capacity());
     ///     assert_eq!(expected.len(), buf.len());
     /// }
     /// ```
@@ -483,8 +475,7 @@ where
         let pads = mode.pads(n_items_diff);
         buffer.extend_from_slice(&std::iter::repeat_n(symbol, pads.left()).collect::<Vec<T>>());
         buffer.extend_from_slice(self);
-        buffer.extend_from_slice(&std::iter::repeat_n(symbol, pads.right()).collect::<Vec<T>>());
-        buffer.shrink_to_fit();
+        buffer.resize(width, symbol);
     }
 }
 
@@ -530,7 +521,6 @@ where
     /// let s: &[i32] = &[1, 2, 3, 4];
     /// let o = s.pad(9, Alignment::Left, 1337i32);
     /// assert_eq!(Vec::from(&[1, 2, 3, 4, 1337, 1337, 1337, 1337, 1337]), o);
-    /// assert_eq!(9, o.capacity());
     /// assert_eq!(9, o.len());
     /// ```
     fn pad(&self, width: usize, mode: Alignment, symbol: Self::Symbol) -> Self::Output {
@@ -546,9 +536,7 @@ where
         let pads = mode.pads(n_items_diff);
         let mut output: Vec<T> = std::iter::repeat_n(symbol, pads.left()).collect::<Vec<T>>();
         output.extend_from_slice(self);
-        output.extend_from_slice(&std::iter::repeat_n(symbol, pads.right()).collect::<Vec<T>>());
-
-        output.shrink_to_fit();
+        output.resize(width, symbol);
         output
     }
 
@@ -573,7 +561,6 @@ where
     /// let s: &[u8] = &[0, 1, 2, 4, 8];
     /// let o = s.pad(7, Alignment::Left, 255u8);
     /// assert_eq!(Vec::from(&[0u8, 1, 2, 4, 8, 255, 255]), o);
-    /// assert_eq!(7, o.capacity());
     /// assert_eq!(7, o.len());
     /// ```
     fn pad_to_buffer(
@@ -597,8 +584,7 @@ where
         let pads = mode.pads(n_items_diff);
         buffer.extend_from_slice(&std::iter::repeat_n(symbol, pads.left()).collect::<Vec<T>>());
         buffer.extend_from_slice(self);
-        buffer.extend_from_slice(&std::iter::repeat_n(symbol, pads.right()).collect::<Vec<T>>());
-        buffer.shrink_to_fit();
+        buffer.resize(width, symbol);
     }
 }
 
@@ -723,7 +709,6 @@ mod tests_str {
         source.pad_to_buffer(width, Alignment::Center, 'ツ', &mut buffer);
         let expected = String::from("godwyn");
         assert_eq!(expected, buffer);
-        assert_eq!(expected.capacity(), buffer.capacity());
         assert_eq!(expected.len(), buffer.len());
     }
 }
@@ -775,7 +760,6 @@ mod tests_string {
         let output: String = source.pad(width, Alignment::Right, '|');
         let expected = String::from("3y");
         assert_eq!(expected, output);
-        assert_eq!(expected.capacity(), output.capacity());
         assert_eq!(expected.len(), output.len());
     }
     #[test]
@@ -827,7 +811,6 @@ mod tests_string {
         let mut expected = String::with_capacity(width);
         expected.push_str("mount gelmir....");
         assert_eq!(expected.len(), buffer.len());
-        assert_eq!(expected.capacity(), buffer.capacity());
         assert_eq!(expected, buffer);
     }
 
@@ -840,7 +823,6 @@ mod tests_string {
         let mut expected = String::with_capacity(width);
         expected.push_str(";;;;mount gelmir");
         assert_eq!(expected.len(), buffer.len());
-        assert_eq!(expected.capacity(), buffer.capacity());
         assert_eq!(expected, buffer);
     }
 
@@ -853,7 +835,6 @@ mod tests_string {
         let mut expected = String::with_capacity(width);
         expected.push_str("--mount gelmir--");
         assert_eq!(expected.len(), buffer.len());
-        assert_eq!(expected.capacity(), buffer.capacity());
         assert_eq!(expected, buffer);
     }
 
@@ -866,7 +847,6 @@ mod tests_string {
         let mut expected = String::with_capacity(width);
         expected.push_str("--mount gelmir---");
         assert_eq!(expected.len(), buffer.len());
-        assert_eq!(expected.capacity(), buffer.capacity());
         assert_eq!(expected, buffer);
     }
 
@@ -878,7 +858,6 @@ mod tests_string {
         source.pad_to_buffer(width, Alignment::Right, ';', &mut buffer);
         let expected = String::from("gelmir");
         assert_eq!(expected.len(), buffer.len());
-        assert_eq!(expected.capacity(), buffer.capacity());
         assert_eq!(expected, buffer);
     }
 
@@ -890,7 +869,6 @@ mod tests_string {
         source.pad_to_buffer(width, Alignment::Right, ';', &mut buffer);
         let expected = String::from("mount„gelmir");
         assert_eq!(expected.len(), buffer.len());
-        assert_eq!(expected.capacity(), buffer.capacity());
         assert_eq!(expected, buffer);
     }
 }
@@ -976,7 +954,6 @@ mod tests_vec {
         let source = Vec::from(&[190u8, 1, 98, 190]);
         let output = source.pad(width, Alignment::Center, 123u8);
         assert_eq!(expected.len(), output.len());
-        assert_eq!(expected.capacity(), output.capacity());
         assert_eq!(expected, output);
     }
 
@@ -999,7 +976,6 @@ mod tests_vec {
         let mut expected = Vec::with_capacity(width);
         expected.extend_from_slice(&[1u8, 0, 1, 9, 9]);
         assert_eq!(expected.len(), buffer.len());
-        assert_eq!(expected.capacity(), buffer.capacity());
         assert_eq!(expected, buffer);
     }
 
@@ -1012,7 +988,6 @@ mod tests_vec {
         let mut expected = Vec::with_capacity(width);
         expected.extend_from_slice(&[254u8, 254, 254, 1, 0, 1]);
         assert_eq!(expected.len(), buffer.len());
-        assert_eq!(expected.capacity(), buffer.capacity());
         assert_eq!(expected, buffer);
     }
 
@@ -1025,7 +1000,6 @@ mod tests_vec {
         let mut expected = Vec::with_capacity(width);
         expected.extend_from_slice(&[1u8, 0, 1, 2, 148]);
         assert_eq!(expected.len(), buffer.len());
-        assert_eq!(expected.capacity(), buffer.capacity());
         assert_eq!(expected, buffer);
     }
 
@@ -1038,7 +1012,6 @@ mod tests_vec {
         let mut expected = Vec::with_capacity(width);
         expected.extend_from_slice(&[148u8, 1, 0, 1, 2, 148]);
         assert_eq!(expected.len(), buffer.len());
-        assert_eq!(expected.capacity(), buffer.capacity());
         assert_eq!(expected, buffer);
     }
 
@@ -1050,7 +1023,6 @@ mod tests_vec {
         source.pad_to_buffer(width, Alignment::Center, 148u8, &mut buffer);
         let expected = Vec::from(&[0u8, 1]);
         assert_eq!(expected.len(), buffer.len());
-        assert_eq!(expected.capacity(), buffer.capacity());
         assert_eq!(expected, buffer);
     }
 
@@ -1062,7 +1034,6 @@ mod tests_vec {
         source.pad_to_buffer(width, Alignment::Center, 148u8, &mut buffer);
         let expected = Vec::from(&[1u8, 0, 1, 2]);
         assert_eq!(expected.len(), buffer.len());
-        assert_eq!(expected.capacity(), buffer.capacity());
         assert_eq!(expected, buffer);
     }
 }
@@ -1087,7 +1058,6 @@ mod tests_slice {
             DummyStruct { a: 4, b: 5 },
             DummyStruct { a: 4, b: 5 },
         ]);
-        assert_eq!(expected.capacity(), output.capacity());
         assert_eq!(expected.len(), output.len());
         assert_eq!(expected, output);
     }
@@ -1102,7 +1072,6 @@ mod tests_slice {
             DummyStruct { a: 4, b: 5 },
             DummyStruct { a: 2, b: 3 },
         ]);
-        assert_eq!(expected.capacity(), output.capacity());
         assert_eq!(expected.len(), output.len());
         assert_eq!(expected, output);
     }
@@ -1117,7 +1086,6 @@ mod tests_slice {
             DummyStruct { a: 2, b: 3 },
             DummyStruct { a: 4, b: 5 },
         ]);
-        assert_eq!(expected.capacity(), output.capacity());
         assert_eq!(expected.len(), output.len());
         assert_eq!(expected, output);
     }
@@ -1133,7 +1101,6 @@ mod tests_slice {
             DummyStruct { a: 4, b: 5 },
             DummyStruct { a: 4, b: 5 },
         ]);
-        assert_eq!(expected.capacity(), output.capacity());
         assert_eq!(expected.len(), output.len());
         assert_eq!(expected, output);
     }
@@ -1145,7 +1112,6 @@ mod tests_slice {
         let output = source.pad(width, Alignment::Left, DummyStruct { a: 13, b: 98 });
         let expected: Vec<DummyStruct> = Vec::with_capacity(0);
         assert_eq!(expected, output);
-        assert_eq!(expected.capacity(), output.capacity());
         assert_eq!(expected.len(), output.len());
     }
 
@@ -1156,7 +1122,6 @@ mod tests_slice {
         let output = source.pad(width, Alignment::Left, DummyStruct { a: 13, b: 98 });
         let expected: Vec<DummyStruct> = Vec::from(&[DummyStruct { a: 2, b: 3 }]);
         assert_eq!(expected, output);
-        assert_eq!(expected.capacity(), output.capacity());
         assert_eq!(expected.len(), output.len());
     }
 
@@ -1168,7 +1133,6 @@ mod tests_slice {
         source.pad_to_buffer(width, Alignment::Left, ' ', &mut buffer);
         let expected = Vec::from(&['a']);
         assert_eq!(expected, buffer);
-        assert_eq!(expected.capacity(), buffer.capacity());
         assert_eq!(expected.len(), buffer.len());
     }
 
@@ -1180,7 +1144,6 @@ mod tests_slice {
         source.pad_to_buffer(width, Alignment::Right, ' ', &mut buffer);
         let expected = Vec::from(&['c']);
         assert_eq!(expected, buffer);
-        assert_eq!(expected.capacity(), buffer.capacity());
         assert_eq!(expected.len(), buffer.len());
     }
 
@@ -1192,7 +1155,6 @@ mod tests_slice {
         source.pad_to_buffer(width, Alignment::Center, ' ', &mut buffer);
         let expected = Vec::from(&['b']);
         assert_eq!(expected, buffer);
-        assert_eq!(expected.capacity(), buffer.capacity());
         assert_eq!(expected.len(), buffer.len());
     }
 
@@ -1204,7 +1166,6 @@ mod tests_slice {
         source.pad_to_buffer(width, Alignment::Center, ' ', &mut buffer);
         let expected = Vec::from(&['a', 'b', 'c']);
         assert_eq!(expected, buffer);
-        assert_eq!(expected.capacity(), buffer.capacity());
         assert_eq!(expected.len(), buffer.len());
     }
 }


### PR DESCRIPTION
improves performance drastically for left aligned padd (when adding to the right of a vec)